### PR TITLE
many args in log functions

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -26,8 +26,14 @@ class Logger
     colorify: (text, color) ->
         "#{color[0]}#{text}#{color[1]}"
 
-    format: (level, text) ->
-        text = JSON.stringify text if text instanceof Object
+    stringify: (text) ->
+        if text instanceof Object
+            text = JSON.stringify text
+        return text
+
+    format: (level, texts) ->
+        text = (@stringify text for text in texts).join(" ")
+
         text = "#{@options.prefix} | #{text}" if @options.prefix?
 
         if process.env.NODE_ENV isnt 'production'
@@ -39,20 +45,20 @@ class Logger
             text = "[#{date}] #{text}"
         text
 
-    info: (text) ->
-        console.info @format 'info', text if process.env.NODE_ENV isnt 'test'
+    info: (texts...) ->
+        console.info @format 'info', texts if process.env.NODE_ENV isnt 'test'
 
-    warn: (text) ->
-        console.warn @format 'warn', text if process.env.NODE_ENV isnt 'test'
+    warn: (texts...) ->
+        console.warn @format 'warn', texts if process.env.NODE_ENV isnt 'test'
 
-    error: (text) ->
-        console.error @format 'error', text if process.env.NODE_ENV isnt 'test'
+    error: (texts...) ->
+        console.error @format 'error', texts if process.env.NODE_ENV isnt 'test'
 
-    debug: (text) ->
-        console.info @format 'debug', text if process.env.DEBUG
+    debug: (texts...) ->
+        console.info @format 'debug', texts if process.env.DEBUG
 
-    raw: (text) ->
-        console.log text
+    raw: (texts...) ->
+        console.log.apply console, texts
 
     lineBreak: (text) ->
         @raw Array(80).join("*")


### PR DESCRIPTION
Tested on : 
```
log.info("two", "arguments")
log.debug("two", ["arguments", "args"])
log.warn("two", "arguments": "args")
log.info()
log.raw("two", "arguments": "args")
```

and on the basics (examples) :
```
log = printit({
  prefix: 'my app',
  date: true
})

log.info("Print this with a blue info label and my app prefix and date")
log.debug("Print this with a green debug label and my app prefix and date")
log.warn("Print this with a yellow warn label and my app prefix and date")
log.error("Print this with a red error label and my app prefix and date")

log = printit({
  prefix: 'my app',
  date: false
})
log.error("Print this with a red error label and my app prefix")

log.error("Test 7")
log.error("Print this with a red error label")
```