### PR TITLE
display filename and line in log.error

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -52,6 +52,18 @@ class Logger
         console.warn @format 'warn', texts if process.env.NODE_ENV isnt 'test'
 
     error: (texts...) ->
+        stacklist = (new Error()).stack.split('\n').slice(2);
+        stackReg = /at\s+(.*)\s+\((.*):(\d*):(\d*)\)/gi;
+        stackReg2 = /at\s+()(.*):(\d*):(\d*)/gi;
+
+        s = stacklist[0]
+        sp = stackReg.exec(s) or stackReg2.exec(s)
+
+        filePath = sp[2].substr(process.cwd().length)
+        line = sp[3]
+        errDetails = ".#{filePath}:#{line} |"
+        texts.unshift(errDetails)
+
         console.error @format 'error', texts if process.env.NODE_ENV isnt 'test'
 
     debug: (texts...) ->


### PR DESCRIPTION
Hey,

(I wasted today a lot of time to find wich log.error was printing.)

I wrote some code to display the filename and the line number in log.error

Maybe we should add an option to disable this, and to activate for others log functions ? .. like this :
```
    constructor: (@options) ->
        @options ?= {}
        if @options.date and not @options.dateFormat?
            @options.dateFormat = 'YYYY-MM-DD hh:mm:ss:S'
        default =
            error: true
            info: false
            warn: false
            debug: false
       @options = _.defaults default, @options
```
