### PR TITLE
Fix bad file from stack

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -32,7 +32,7 @@ class Logger
         return text
 
     getFileAndLine: ->
-        stacklist = (new Error()).stack.split('\n').slice(3)
+        stacklist = (new Error()).stack.split('\n').slice(4)
         nodeReg = /at\s+(.*)\s+\((.*):(\d*):(\d*)\)/gi
         browserReg = /at\s+()(.*):(\d*):(\d*)/gi
 


### PR DESCRIPTION
In `getFileAndLine`, remove the 4 first lines:

    Error
      at Logger.getFileAndLine (.../node_modules/printit/main.js:51:18)
      at Logger.format (.../node_modules/printit/main.js:65:26)
      at Logger.debug (.../node_modules/printit/main.js:120:32)

Fix #11