### PR TITLE
Display nicely Errors

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -27,7 +27,9 @@ class Logger
         "#{color[0]}#{text}#{color[1]}"
 
     stringify: (text) ->
-        if text instanceof Object
+        if text instanceof Error
+            text = text.stack
+        else if text instanceof Object
             text = JSON.stringify text
         return text
 


### PR DESCRIPTION
Before:

```
error - Remote watcher | ./backend/remote/watcher.coffee:133 | {}
```

After:

```
error - Remote watcher | ./backend/remote/watcher.coffee:133 | Error: Invalid checksum
  at Merge.putFile (/home/nono/cc/desktop/backend/merge.coffee:156:26)
  at Merge.putDoc (/home/nono/cc/desktop/backend/merge.coffee:109:14)
  at Merge.putDoc (/home/nono/cc/desktop/backend/merge.coffee:1:1)
  at RemoteWatcher.putDoc (/home/nono/cc/desktop/backend/remote/watcher.coffee:121:20)
  at RemoteWatcher.putDoc (/home/nono/cc/desktop/backend/remote/watcher.coffee:1:1)
  at /home/nono/cc/desktop/backend/remote/watcher.coffee:98:18
  at /home/nono/cc/desktop/backend/pouch.coffee:91:17
  at /home/nono/cc/desktop/node_modules/pouchdb/lib/mapreduce/utils.js:9:9
  at process._tickCallback (node.js:448:13)
```