### PR TITLE
Fix an error when logging null

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -27,7 +27,7 @@ class Logger
         "#{color[0]}#{text}#{color[1]}"
 
     stringify: (text) ->
-        if text.stack and text instanceof Error
+        if text instanceof Error and text.stack
             text = text.stack
         else if text instanceof Object
             text = JSON.stringify text


### PR DESCRIPTION
When doing logger.info(null), printit crashed with this error:

    TypeError: Cannot read property 'stack' of null